### PR TITLE
Add SEC filing parser using PyMuPDF4LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# SaaS-Multiples
+# SaaS Multiples
+
+This repository provides a small utility for extracting metadata and basic financial
+information from SEC filing PDFs. It uses [PyMuPDF4LLM](https://github.com/ArtifexSoftware/pymupdf4llm) from Artifex to convert PDF pages to markdown and searches the text for
+common financial terms such as **Total Revenue** or **Net Income**.
+
+## Installation
+
+Create a Python virtual environment and install dependencies:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the parser on a SEC filing PDF:
+
+```bash
+python sec_metadata/parser.py path/to/filing.pdf --pages 1-5
+```
+
+This will print a JSON structure containing the document's metadata along with any
+financial terms discovered in the given pages.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pymupdf>=1.23
+pymupdf4llm>=0.0.20

--- a/sec_metadata/__init__.py
+++ b/sec_metadata/__init__.py
@@ -1,0 +1,4 @@
+"""Utilities to parse SEC filings and extract basic financial information."""
+from .parser import extract_financial_info, parse_page_range
+
+__all__ = ["extract_financial_info", "parse_page_range"]

--- a/sec_metadata/parser.py
+++ b/sec_metadata/parser.py
@@ -1,0 +1,66 @@
+import json
+import re
+import pymupdf
+import pymupdf4llm
+
+
+FINANCIAL_TERMS = [
+    "total revenue",
+    "net income",
+    "net loss",
+]
+
+VALUE_RE = re.compile(r"\$?\(?\d{1,3}(?:,\d{3})*(?:\.\d+)?\)?")
+TERM_RE = re.compile(r"(" + "|".join(re.escape(t) for t in FINANCIAL_TERMS) + r")", re.IGNORECASE)
+
+
+def extract_financial_info(pdf_path: str, pages=None):
+    """Return document metadata and simple financial values."""
+    doc = pymupdf.open(pdf_path)
+    md_pages = pymupdf4llm.to_markdown(doc, pages=pages, page_chunks=True)
+
+    results = {
+        "file_path": pdf_path,
+        "doc_metadata": doc.metadata,
+        "items": [],
+    }
+
+    for page in md_pages:
+        page_no = page["metadata"]["page_number"]
+        for line in page["text"].splitlines():
+            term_match = TERM_RE.search(line)
+            if term_match:
+                value_match = VALUE_RE.search(line)
+                if value_match:
+                    results["items"].append(
+                        {
+                            "page": page_no,
+                            "term": term_match.group(1).title(),
+                            "value": value_match.group(0),
+                        }
+                    )
+    return results
+
+
+def parse_page_range(page_range: str):
+    """Convert a 1-based page range like '1-3' to a list of 0-based pages."""
+    start, end = [int(p) for p in page_range.split("-", 1)]
+    return list(range(start - 1, end))
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Extract metadata and financial terms from a SEC filing PDF"
+    )
+    parser.add_argument("pdf", help="Path to PDF file")
+    parser.add_argument(
+        "--pages",
+        help="Optional page range like '1-10'",
+    )
+    args = parser.parse_args()
+
+    pages = parse_page_range(args.pages) if args.pages else None
+    data = extract_financial_info(args.pdf, pages=pages)
+    print(json.dumps(data, indent=2))


### PR DESCRIPTION
## Summary
- set up a small parser package `sec_metadata`
- implement `extract_financial_info` CLI that searches for Total Revenue and Net Income in filings
- document usage in README
- provide `requirements.txt` for dependency installation

## Testing
- `python -m py_compile sec_metadata/parser.py`
- `pip install -r requirements.txt`
- `python sec_metadata/parser.py --help`


------
https://chatgpt.com/codex/tasks/task_b_688b7b20ef98832f91fcbe32b7920681