### PR TITLE
Enhance page range parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Run the parser on a SEC filing PDF:
 python sec_metadata/parser.py path/to/filing.pdf --pages 1-5
 ```
 
+The `--pages` option accepts a single page number like `3` or a
+range such as `1-5`.  Numbers are 1-based and the range's start must
+not exceed its end.  Any other format will raise a `ValueError`.
+
 This will print a JSON structure containing the document's metadata along with any
 financial terms discovered in the given pages.
 

--- a/sec_metadata/parser.py
+++ b/sec_metadata/parser.py
@@ -43,9 +43,29 @@ def extract_financial_info(pdf_path: str, pages=None):
 
 
 def parse_page_range(page_range: str):
-    """Convert a 1-based page range like '1-3' to a list of 0-based pages."""
-    start, end = [int(p) for p in page_range.split("-", 1)]
-    return list(range(start - 1, end))
+    """Convert a page range string to a list of 0-based page numbers.
+
+    Accepted formats are a single integer (e.g. ``"3"``) or a range
+    ``"start-end"`` where both numbers are 1-based.  A single value will be
+    converted to the corresponding zero-based page index, while a range will
+    return all pages between ``start`` and ``end`` (inclusive).
+    """
+
+    page_range = page_range.strip()
+
+    # Single page specification like ``"3"``
+    if re.fullmatch(r"\d+", page_range):
+        return [int(page_range) - 1]
+
+    # Range specification like ``"1-5"``
+    m = re.fullmatch(r"(\d+)\s*-\s*(\d+)", page_range)
+    if m:
+        start, end = int(m.group(1)), int(m.group(2))
+        if start > end:
+            raise ValueError(f"page range start {start} is greater than end {end}")
+        return list(range(start - 1, end))
+
+    raise ValueError(f"Unrecognized page range format: '{page_range}'")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend `parse_page_range` to handle single pages
- validate range ordering and throw a clear error for bad formats
- document supported `--pages` syntax in README

## Testing
- `python -m py_compile sec_metadata/parser.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_688b8d00841c832f98da0072dde6d949