### PR TITLE
Expand parser regex to match additional number formats

### DIFF
--- a/sec_metadata/parser.py
+++ b/sec_metadata/parser.py
@@ -10,7 +10,18 @@ FINANCIAL_TERMS = [
     "net loss",
 ]
 
-VALUE_RE = re.compile(r"\$?\(?\d{1,3}(?:,\d{3})*(?:\.\d+)?\)?")
+VALUE_RE = re.compile(
+    r"""
+    \$?  # optional dollar sign
+    (?:
+        -?\d+(?:,\d{3})*(?:\.\d+)?  # optional negative sign with digits
+        |\(
+            \d+(?:,\d{3})*(?:\.\d+)?  # digits enclosed in parentheses
+        \)
+    )
+    """,
+    re.VERBOSE,
+)
 TERM_RE = re.compile(r"(" + "|".join(re.escape(t) for t in FINANCIAL_TERMS) + r")", re.IGNORECASE)
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from sec_metadata.parser import VALUE_RE
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("Revenue was 1000", "1000"),
+        ("Loss was -1000", "-1000"),
+        ("Loss was (1000)", "(1000)"),
+        ("Loss was $(1000)", "$(1000)"),
+        ("Income was $-1,000", "$-1,000"),
+        ("Revenue was 1,000", "1,000"),
+    ],
+)
+def test_value_re(text, expected):
+    match = VALUE_RE.search(text)
+    assert match is not None
+    assert match.group(0) == expected
+


### PR DESCRIPTION
## Summary
- extend `VALUE_RE` regex to handle plain digit strings and negative signs
- add unit tests for the new patterns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688b8d08805c832fbe26ecaeecdee0fe