### PR TITLE
Add pytest configuration and sample tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ python sec_metadata/parser.py path/to/filing.pdf --pages 1-5
 This will print a JSON structure containing the document's metadata along with any
 financial terms discovered in the given pages.
 
+
+## Running Tests
+
+After installing the requirements, run the test suite with:
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pymupdf>=1.23
 pymupdf4llm>=0.0.20
+pytest>=7.0

--- a/sec_metadata/parser.py
+++ b/sec_metadata/parser.py
@@ -26,7 +26,8 @@ def extract_financial_info(pdf_path: str, pages=None):
     }
 
     for page in md_pages:
-        page_no = page["metadata"]["page_number"]
+        meta = page.get("metadata", {})
+        page_no = meta.get("page_number") or meta.get("page")
         for line in page["text"].splitlines():
             term_match = TERM_RE.search(line)
             if term_match:

--- a/tests/data/sample.pdf
+++ b/tests/data/sample.pdf
@@ -1,0 +1,51 @@
+%PDF-1.7
+%µ¶
+
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+
+2 0 obj
+<</Type/Pages/Count 1/Kids[4 0 R]>>
+endobj
+
+3 0 obj
+<</Font<</helv 5 0 R>>>>
+endobj
+
+4 0 obj
+<</Type/Page/MediaBox[0 0 595 842]/Rotate 0/Resources 3 0 R/Parent 2 0 R/Contents[6 0 R]>>
+endobj
+
+5 0 obj
+<</Type/Font/Subtype/Type1/BaseFont/Helvetica/Encoding/WinAnsiEncoding>>
+endobj
+
+6 0 obj
+<</Length 126/Filter/FlateDecode>>
+stream
+x51
+A>$ ,[6vt3Xha]Տt,4/=ê\;OC8z:I"@@dB-bsZ$ت:#MePqG:TB_"
+endstream
+endobj
+
+7 0 obj
+<</Title(Sample Filing)/Author(Test Corp)>>
+endobj
+
+xref
+0 8
+0000000000 65535 f 
+0000000016 00000 n 
+0000000062 00000 n 
+0000000114 00000 n 
+0000000155 00000 n 
+0000000262 00000 n 
+0000000351 00000 n 
+0000000546 00000 n 
+
+trailer
+<</Size 8/Info 7 0 R/Root 1 0 R/ID[<15C39BC289C2A4C3A7C2BDC398C3B141><EA5C07E82944588081B879071A149A81>]>>
+startxref
+606
+%%EOF

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,36 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import fitz
+import pytest
+import pymupdf4llm
+from sec_metadata import extract_financial_info
+
+
+SAMPLE_PDF = os.path.join(os.path.dirname(__file__), 'data', 'sample.pdf')
+
+
+def test_extract_financial_info_success():
+    result = extract_financial_info(SAMPLE_PDF)
+    assert result['doc_metadata']['title'] == 'Sample Filing'
+    terms = {(item['term'], item['value']) for item in result['items']}
+    assert ('Total Revenue', '$10,000') in terms
+    assert ('Net Income', '$2,000') in terms
+
+
+def test_missing_metadata(monkeypatch):
+    real_to_md = pymupdf4llm.to_markdown
+
+    def fake_to_markdown(doc, *args, **kwargs):
+        result = real_to_md(doc, *args, **kwargs)
+        # simulate missing metadata after extraction
+        doc.metadata = {}
+        return result
+
+    monkeypatch.setattr(pymupdf4llm, "to_markdown", fake_to_markdown)
+    result = extract_financial_info(SAMPLE_PDF)
+    assert result['doc_metadata'] == {}
+    # terms should still be extracted
+    assert any(item['term'] == 'Total Revenue' for item in result['items'])
+


### PR DESCRIPTION
## Summary
- add a minimal pytest suite with a sample PDF
- handle alternate page metadata field in the parser
- document running `pytest`
- include pytest in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688b8d0eaa04832fadcd80dec16a2a23