### PR TITLE
Expand metrics extraction and add report collector

### DIFF
--- a/collect_reports.py
+++ b/collect_reports.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+from sec_metadata.parser import extract_financial_info, FINANCIAL_TERMS
+
+
+def main():
+    company = input("Enter company name: ").strip()
+    folder = Path("reports") / company.replace(" ", "_")
+    folder.mkdir(parents=True, exist_ok=True)
+    collected = {}
+
+    missing = [t.title() for t in FINANCIAL_TERMS]
+    while missing:
+        pdf_path = input(
+            f"Provide path to PDF with data (missing: {', '.join(missing)}): "
+        ).strip()
+        if not pdf_path:
+            print("No PDF provided. Exiting.")
+            return
+        data = extract_financial_info(pdf_path)
+        for item in data.get("items", []):
+            collected.setdefault(item["term"], item["value"])
+        missing = [t.title() for t in FINANCIAL_TERMS if t.title() not in collected]
+        report_path = folder / "report.md"
+        with report_path.open("w", encoding="utf-8") as f:
+            f.write(f"# {company} Financial Metrics\n\n")
+            for term, value in collected.items():
+                f.write(f"- {term}: {value}\n")
+        if missing:
+            print("Missing information:", ", ".join(missing))
+    print("All financial data collected. Report saved at", report_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/sec_metadata/__init__.py
+++ b/sec_metadata/__init__.py
@@ -1,4 +1,4 @@
 """Utilities to parse SEC filings and extract basic financial information."""
-from .parser import extract_financial_info, parse_page_range
+from .parser import FINANCIAL_TERMS, extract_financial_info, parse_page_range
 
-__all__ = ["extract_financial_info", "parse_page_range"]
+__all__ = ["extract_financial_info", "parse_page_range", "FINANCIAL_TERMS"]

--- a/sec_metadata/parser.py
+++ b/sec_metadata/parser.py
@@ -12,6 +12,18 @@ FINANCIAL_TERMS = [
     "total revenue",
     "net income",
     "net loss",
+    "ebitda",
+    "operating income",
+    "debt",
+    "cash and cash equivalents",
+    "annual recurring revenue",
+    "monthly recurring revenue",
+    "gross churn rate",
+    "net churn rate",
+    "expansion mrr",
+    "expansion arr",
+    "sales and marketing",
+    "customer acquisition cost",
 ]
 
 VALUE_RE = re.compile(
@@ -27,6 +39,8 @@ VALUE_RE = re.compile(
     re.VERBOSE,
 )
 TERM_RE = re.compile(r"(" + "|".join(re.escape(t) for t in FINANCIAL_TERMS) + r")", re.IGNORECASE)
+
+PERCENT_RE = re.compile(r"-?\d+(?:\.\d+)?%")
 
 
 def extract_financial_info(pdf_path: str, pages=None):
@@ -46,7 +60,7 @@ def extract_financial_info(pdf_path: str, pages=None):
         for line in page["text"].splitlines():
             term_match = TERM_RE.search(line)
             if term_match:
-                value_match = VALUE_RE.search(line)
+                value_match = VALUE_RE.search(line) or PERCENT_RE.search(line)
                 if value_match:
                     results["items"].append(
                         {
@@ -55,6 +69,8 @@ def extract_financial_info(pdf_path: str, pages=None):
                             "value": value_match.group(0),
                         }
                     )
+    found_terms = {item["term"].lower() for item in results["items"]}
+    results["missing_terms"] = [t.title() for t in FINANCIAL_TERMS if t.lower() not in found_terms]
     return results
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -11,22 +11,33 @@ from sec_metadata import extract_financial_info
 SAMPLE_PDF = os.path.join(os.path.dirname(__file__), 'data', 'sample.pdf')
 
 
-def test_extract_financial_info_success():
+def test_extract_financial_info_success(monkeypatch):
+    def fake_to_markdown(doc, *args, **kwargs):
+        return [
+            {
+                "text": "Total Revenue $10,000\nNet Income $2,000",
+                "metadata": {"page": 1},
+            }
+        ]
+
+    monkeypatch.setattr(pymupdf4llm, "to_markdown", fake_to_markdown)
     result = extract_financial_info(SAMPLE_PDF)
     assert result['doc_metadata']['title'] == 'Sample Filing'
     terms = {(item['term'], item['value']) for item in result['items']}
     assert ('Total Revenue', '$10,000') in terms
     assert ('Net Income', '$2,000') in terms
+    assert 'Ebitda' in result['missing_terms']
 
 
 def test_missing_metadata(monkeypatch):
-    real_to_md = pymupdf4llm.to_markdown
-
     def fake_to_markdown(doc, *args, **kwargs):
-        result = real_to_md(doc, *args, **kwargs)
-        # simulate missing metadata after extraction
         doc.metadata = {}
-        return result
+        return [
+            {
+                "text": "Total Revenue $10,000\nNet Income $2,000",
+                "metadata": {},
+            }
+        ]
 
     monkeypatch.setattr(pymupdf4llm, "to_markdown", fake_to_markdown)
     result = extract_financial_info(SAMPLE_PDF)


### PR DESCRIPTION
## Summary
- broaden parser regex to extract common SaaS metrics and track missing terms
- expose FINANCIAL_TERMS and add interactive report collector script
- test parser behaviour with mocked Markdown extraction

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_688d4fca6f28833084d6f2b08bf17569