### PR TITLE
Add pdfminer fallback for SEC parser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pymupdf>=1.23
 pymupdf4llm>=0.0.20
 pytest>=7.0
+pdfminer.six>=20231228

--- a/sec_metadata/parser.py
+++ b/sec_metadata/parser.py
@@ -1,8 +1,10 @@
 import json
 import logging
 import re
+
 import pymupdf
 import pymupdf4llm
+from pdfminer.high_level import extract_text
 
 
 logger = logging.getLogger(__name__)
@@ -32,17 +34,25 @@ TERM_RE = re.compile(r"(" + "|".join(re.escape(t) for t in FINANCIAL_TERMS) + r"
 def extract_financial_info(pdf_path: str, pages=None):
     """Return document metadata and simple financial values."""
     doc = pymupdf.open(pdf_path)
-    md_pages = pymupdf4llm.to_markdown(doc, pages=pages, page_chunks=True)
+    try:
+        md_pages = pymupdf4llm.to_markdown(doc, pages=pages, page_chunks=True)
+        if not any(page.get("text") for page in md_pages):
+            raise RuntimeError("empty")
+        metadata = doc.metadata
+    except Exception:
+        metadata = doc.metadata
+        text = extract_text(pdf_path, page_numbers=pages)
+        md_pages = [{"text": text, "metadata": {"page_number": 1}}]
 
     results = {
         "file_path": pdf_path,
-        "doc_metadata": doc.metadata,
+        "doc_metadata": metadata,
         "items": [],
     }
 
     for page in md_pages:
         meta = page.get("metadata", {})
-        page_no = meta.get("page_number") or meta.get("page")
+        page_no = meta.get("page_number") or meta.get("page") or 1
         for line in page["text"].splitlines():
             term_match = TERM_RE.search(line)
             if term_match:

--- a/tests/data/sample.pdf
+++ b/tests/data/sample.pdf
@@ -22,11 +22,13 @@ endobj
 endobj
 
 6 0 obj
-<</Length 126/Filter/FlateDecode>>
+<</Length 117/Filter/FlateDecode>>
 stream
-x51
-A>$ ,[6vt3Xha]Տt,4/=ê\;OC8z:I"@@dB-bsZ$ت:#MePqG:TB_"
-endstream
+xU˱
+P=_Pt]܄lũ⠃o9eƙݽ?ެʵ4cIb6	C$Mln5^LsiM|߳u*Q
+0000000537 00000 n 
+<</Size 8/Info 7 0 R/Root 1 0 R/ID[<C3BC6D7D51C387C3A7C284C3B7C29970><B24DDBF5E8CEE4E6B95A3D45494E1517>]>>
+597
 endobj
 
 7 0 obj

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -35,3 +35,15 @@ def test_missing_metadata(monkeypatch):
     assert any(item['term'] == 'Total Revenue' for item in result['items'])
 
 
+def test_pdfminer_fallback(monkeypatch):
+    """If MuPDF cannot extract text, fall back to pdfminer."""
+
+    def boom(*args, **kwargs):  # force fallback
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(pymupdf4llm, "to_markdown", boom)
+    result = extract_financial_info(SAMPLE_PDF)
+    terms = {(item['term'], item['value']) for item in result['items']}
+    assert ('Total Revenue', '$10,000') in terms
+
+


### PR DESCRIPTION
## Summary
- use `pdfminer.six` as a fallback when PyMuPDF cannot extract text
- expand tests with pdfminer fallback scenario

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_688d4f8588f08330901e0d225417587e